### PR TITLE
Show gist's description in the quick_panel

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,17 @@ Release History
 
 ---------------
 
+0.2.7 (2015-08-03)
+++++++++++++++++++
+* Enhancement: show gist description in the palette if available. This helps users search through their gists easier.
+
+
+0.2.6 (2015-08-03)
+++++++++++++++++++
+* Fix bug for command ``Add File to Gist``
+* Fix bug for command ``Delete File from Gist``
+
+
 0.2.5 (2015-08-03)
 ++++++++++++++++++
 * Fix progress message problem when one gist has multiple files

--- a/config/messages/0.2.7.md
+++ b/config/messages/0.2.7.md
@@ -1,0 +1,5 @@
+Build 0.2.7
+-----------
+Release Date: 21 April 2018
+
+* Enhancement: show gist description in the palette if available. This helps users search through their gists easier.

--- a/config/settings/HaoGistPackage.sublime-settings
+++ b/config/settings/HaoGistPackage.sublime-settings
@@ -1,6 +1,6 @@
 {
     "name": "HaoGist",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "HaoGist is sublime plugin for CRUD on Github gist",
     "author": "Hao Liu",
     "email": "mouse.mliu@gmail.com",

--- a/main.py
+++ b/main.py
@@ -98,6 +98,7 @@ class ChooseGist(sublime_plugin.WindowCommand):
                     # Add gist files to items
                     gist_items_property = []
                     for key, value in _gist["files"].items():
+                        filename = key
                         if files_number > 1:
                             key = "%s%s" % (" " * 4, key)
                         else:
@@ -111,7 +112,7 @@ class ChooseGist(sublime_plugin.WindowCommand):
 
                         self.items.append(key)
                         self.items_property[key] = [{
-                            "fileName": key.strip(),
+                            "fileName": filename,
                             "fileProperty": value,
                             "gist": _gist
                         }]

--- a/main.py
+++ b/main.py
@@ -100,6 +100,15 @@ class ChooseGist(sublime_plugin.WindowCommand):
                     for key, value in _gist["files"].items():
                         if files_number > 1:
                             key = "%s%s" % (" " * 4, key)
+                        else:
+                            key = _gist["description"] or key
+                            if key in self.items:
+                                self._update_item_title(key)
+                                key = "{key} ({filename})".format(
+                                    key=key,
+                                    filename=value["filename"],
+                                )
+
                         self.items.append(key)
                         self.items_property[key] = [{
                             "fileName": key.strip(),
@@ -113,6 +122,19 @@ class ChooseGist(sublime_plugin.WindowCommand):
 
             self.window.show_quick_panel(self.items, self.on_done, 
                 sublime.MONOSPACE_FONT)
+
+    def _update_item_title(self, key):
+
+        """ This method finds the item, removes and puts it back in with the new
+            name by appending the filename in the title.
+        """
+        gist = self.items_property[key]
+        gist_filename = gist[0]["fileProperty"]["filename"]
+        new_key = "{key} ({filename})".format(key=key, filename=gist_filename)
+        self.items.remove(key)
+        self.items.append(new_key)
+        del self.items_property[key]
+        self.items_property[new_key] = gist
 
     def on_done(self, index):
         if index == -1: return

--- a/messages.json
+++ b/messages.json
@@ -16,5 +16,6 @@
     "0.2.4": "config/messages/0.2.4.md",
     "0.2.5": "config/messages/0.2.5.md",
     "0.2.6": "config/messages/0.2.6.md",
+    "0.2.7": "config/messages/0.2.7.md",
     "install": "config/messages/install.md"
 }


### PR DESCRIPTION
Instead of showing the file names, it shows the description. It makes it easier to search through gists. It appends the file names if encountered duplicate items. 
Also closes #11 